### PR TITLE
typo in the repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# Zombi_Apocalypse
+# Zombie_Apocalypse
 Tutorial on how to survive.
+
+#please rename the repository to Zombie_Apocalypse


### PR DESCRIPTION
If there is no reason for "Zombi", please change this typo to Zombie.